### PR TITLE
Update get-started.md

### DIFF
--- a/content/en/docs/get-started.md
+++ b/content/en/docs/get-started.md
@@ -110,6 +110,11 @@ kubectl apply -f cozystack-config.yaml
 kubectl apply -f https://github.com/aenix-io/cozystack/raw/v0.9.0/manifests/cozystack-installer.yaml
 ```
 
+If your pods have status "Pending"
+```bash
+kubectl taint nodes --all node-role.kubernetes.io/control-plane-
+```
+
 (optional) You can track the logs of installer:
 ```bash
 kubectl logs -n cozy-system deploy/cozystack -f

--- a/content/en/docs/get-started.md
+++ b/content/en/docs/get-started.md
@@ -110,10 +110,14 @@ kubectl apply -f cozystack-config.yaml
 kubectl apply -f https://github.com/aenix-io/cozystack/raw/v0.9.0/manifests/cozystack-installer.yaml
 ```
 
-If your pods have status "Pending"
+{{% alert color="info" %}}
+Currenlty Cozytack does not separate control-plane and worker nodes, so if your nodes have control-plane taint, pods will stuck in `Pending` status.  
+
+You have to remove control-plane taint from the nodes:
 ```bash
 kubectl taint nodes --all node-role.kubernetes.io/control-plane-
 ```
+{{% /alert %}}
 
 (optional) You can track the logs of installer:
 ```bash


### PR DESCRIPTION
:~$ kubectl get all -n cozy-system

NAMESPACE     NAME                               READY   STATUS    RESTARTS      AGE
cozy-system   pod/cozystack-d965c8bc6-5vftc      0/2     Pending   0             15m

:~$ kubectl describe pod/cozystack-d965c8bc6-5vftc -n cozy-system
...
Events:
  Type     Reason            Age                  From               Message
  ----     ------            ----                 ----               -------
  Warning  FailedScheduling  15m                  default-scheduler  0/2 nodes are available: 2 node(s) had untolerated taint {node-role.kubernetes.io/control-plane: }. preemption: 0/2 nodes are available: 2 Preemption is not helpful for scheduling.
  Warning  FailedScheduling  5m27s (x2 over 10m)  default-scheduler  0/2 nodes are available: 2 node(s) had untolerated taint {node-role.kubernetes.io/control-plane: }. preemption: 0/2 nodes are available: 2 Preemption is not helpful for scheduling.

:~$ kubectl taint nodes --all node-role.kubernetes.io/control-plane-
node/srv1 untainted
node/srv2 untainted
:~$ watrch kubectl get all -A
