### PR TITLE
Switch volumeBindingMode to Immediate in replicated StorageClass

### DIFF
--- a/content/en/docs/get-started.md
+++ b/content/en/docs/get-started.md
@@ -268,7 +268,7 @@ parameters:
   property.linstor.csi.linbit.com/DrbdOptions/Resource/on-no-data-accessible: suspend-io
   property.linstor.csi.linbit.com/DrbdOptions/Resource/on-suspended-primary-outdated: force-secondary
   property.linstor.csi.linbit.com/DrbdOptions/Net/rr-conflict: retry-connect
-volumeBindingMode: WaitForFirstConsumer
+volumeBindingMode: Immediate
 allowVolumeExpansion: true
 EOT
 ```


### PR DESCRIPTION
Temprary switch volumeBindingMode to Immediate, due to fact kubevirt-csi does not work with WaitForFirstConsumer yet

upstream issue: https://github.com/kubevirt/csi-driver/issues/116
