### PR TITLE
add keycloak doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # cozystack-website
 Cozystack.io website
+
+## Install hugo
+```bash
+wget https://github.com/gohugoio/hugo/releases/download/v0.122.0/hugo_extended_0.122.0_linux-amd64.tar.gz
+tar -xzf hugo_extended_0.122.0_linux-amd64.tar.gz
+ chmod +x /usr/local/bin/hugo
+```
+
+## Run docs
+```bash
+hugo serve
+```

--- a/content/en/docs/bundles/distro-full.md
+++ b/content/en/docs/bundles/distro-full.md
@@ -22,6 +22,8 @@ data:
   bundle-name: "distro-full"
   ipv4-pod-cidr: "10.244.0.0/16"
   ipv4-svc-cidr: "10.96.0.0/16"
+  root-host: example.org
+  api-server-endpoint: https://192.168.100.10:6443
 ```
 
 ### Configuration parameters
@@ -33,5 +35,7 @@ data:
 | `values-<component>` | JSON or YAML formated values passed to specific component installation. Refer to [FAQ](/docs/faq/#how-to-overwrite-parameters-for-specific-components) page to learn how to use this option. |
 | `ipv4-pod-cidr` | The pod subnet used by Pods to assign IPs |
 | `ipv4-svc-cidr` | The pod subnet used by Services to assign IPs |
+| `root-host` | the main domain for all services created under Cozystack, such as the dashboard, Grafana, Keycloak, etc. |
+| `api-server-endpoint` | used for generating kubeconfig files for your users. It is recommended to use globally accessible IP addresses instead of local ones. |
 
 Refer to [FAQ](/docs/faq/#bundles) page to learn how to use generic bundle options.

--- a/content/en/docs/bundles/distro-hosted.md
+++ b/content/en/docs/bundles/distro-hosted.md
@@ -20,6 +20,8 @@ metadata:
   namespace: cozy-system
 data:
   bundle-name: "distro-hosted"
+  root-host: example.org
+  api-server-endpoint: https://192.168.100.10:6443
 ```
 
 ### Configuration parameters
@@ -29,7 +31,7 @@ data:
 | `bundle-name` | Name of bundle to use for installation |
 | `bundle-disable` | Comma-separated list of disabled components from the bundle. Refer to [FAQ](/docs/faq/#how-to-disable-some-components-from-bundle) page to learn how to use this option. |
 | `values-<component>` | JSON or YAML formated values passed to specific component installation. Refer to [FAQ](/docs/faq/#how-to-overwrite-parameters-for-specific-components) page to learn how to use this option. |
-| `ipv4-pod-cidr` | The pod subnet used by Pods to assign IPs |
-| `ipv4-svc-cidr` | The pod subnet used by Services to assign IPs |
+| `root-host` | the main domain for all services created under Cozystack, such as the dashboard, Grafana, Keycloak, etc. |
+| `api-server-endpoint` | used for generating kubeconfig files for your users. It is recommended to use globally accessible IP addresses instead of local ones. |
 
 Refer to [FAQ](/docs/faq/#bundles) page to learn how to use generic bundle options.

--- a/content/en/docs/bundles/paas-full.md
+++ b/content/en/docs/bundles/paas-full.md
@@ -23,6 +23,8 @@ data:
   ipv4-pod-gateway: "10.244.0.1"
   ipv4-svc-cidr: "10.96.0.0/16"
   ipv4-join-cidr: "100.64.0.0/16"
+  root-host: example.org
+  api-server-endpoint: https://192.168.100.10:6443
 ```
 
 ### Configuration parameters
@@ -36,3 +38,5 @@ data:
 | `ipv4-pod-gateway` | The gateway address for the pod subnet |
 | `ipv4-svc-cidr` | The pod subnet used by Services to assign IPs |
 | `ipv4-join-cidr` | The `join` subnet, as a special subnet for network communication between the Node and Pod. Follow [kube-ovn](https://kubeovn.github.io/docs/en/guide/subnet/#join-subnet) documentation to learn more about these options. |
+| `root-host` | the main domain for all services created under Cozystack, such as the dashboard, Grafana, Keycloak, etc. |
+| `api-server-endpoint` | used for generating kubeconfig files for your users. It is recommended to use globally accessible IP addresses instead of local ones. |

--- a/content/en/docs/bundles/paas-hosted.md
+++ b/content/en/docs/bundles/paas-hosted.md
@@ -20,6 +20,8 @@ metadata:
   namespace: cozy-system
 data:
   bundle-name: "paas-hosted"
+  root-host: example.org
+  api-server-endpoint: https://192.168.100.10:6443
 ```
 
 ### Configuration parameters
@@ -31,5 +33,7 @@ data:
 | `values-<component>` | JSON or YAML formated values passed to specific component installation. Refer to [FAQ](/docs/faq/#how-to-overwrite-parameters-for-specific-components) page to learn how to use this option. |
 | `ipv4-pod-cidr` | The pod subnet used by Pods to assign IPs |
 | `ipv4-svc-cidr` | The pod subnet used by Services to assign IPs |
+| `root-host` | the main domain for all services created under Cozystack, such as the dashboard, Grafana, Keycloak, etc. |
+| `api-server-endpoint` | used for generating kubeconfig files for your users. It is recommended to use globally accessible IP addresses instead of local ones. |
 
 Refer to [FAQ](/docs/faq/#bundles) page to learn how to use generic bundle options.

--- a/content/en/docs/get-started.md
+++ b/content/en/docs/get-started.md
@@ -346,30 +346,19 @@ EOT
 
 ## Setup basic applications
 
-Get token from `tenant-root`:
+- Set `etcd`, `monitoring` and `ingress` to enabled position
+```bash
+kubectl -n tenant-root patch hr tenant-root --type='merge' -p='{"spec":{"values":{"etcd":{"enabled":true},"monitoring":{"enabled":true},"ingress":{"enabled":true}}}}'
+```
+
+Get token from `tenant-root` (If dont use keycloak):
 ```bash
 kubectl get secret -n tenant-root tenant-root -o go-template='{{ printf "%s\n" (index .data "token" | base64decode) }}'
 ```
 
-Enable port forward to cozy-dashboard:
-```bash
-kubectl port-forward -n cozy-dashboard svc/dashboard 8000:80
-```
-
-Open: http://localhost:8000/
-
-- Select `tenant-root`
-- Click `Upgrade` button
-- Into `host` section write a domain which you're going to use as parent domain for all deployed applications
-
-  {{% alert color="warning" %}}
-  :warning: if you have no domain yet, you can use `192.168.100.200.nip.io` where `192.168.100.200` is a first IP address in your network addresses range.
-
-   alternatively you can leave the default value, however you'll be need to modify your `/etc/hosts` every time you want to access specific application.
-  {{% /alert %}}
-
-- Set `etcd`, `monitoring` and `ingress` to enabled position
-- Click Deploy
+If you use keycloak, open `keycloak.<your-root-host>`
+- Create user in cozy realm [documentation](https://www.keycloak.org/docs/latest/server_admin/index.html#proc-creating-user_server_administration_guide)
+- Add user to `kubeapps-admin` group
 
 {{% alert color="info" %}}
 If you plan to use an external load balancer or a client-side balancer to access your services through the same IPs for your nodes, you have to modify `ingress` application to specify these IPs in `externalIPs`.

--- a/content/en/docs/get-started.md
+++ b/content/en/docs/get-started.md
@@ -353,7 +353,7 @@ kubectl patch -n tenant-root tenants.apps.cozystack.io root --type=merge -p '{"s
 
 If you don't use external load balancer, specify all your external IPs of your nodes for the `ingress` controller:
 
-```
+```bash
 kubectl patch -n tenant-root ingresses.apps.cozystack.io ingress --type=merge -p '{"spec":{
   "externalIPs": [
     "192.168.100.11",
@@ -438,6 +438,14 @@ root-ingress-controller   LoadBalancer   10.96.16.141   192.168.100.200   80:316
 ```
 
 **Cozystack Dashboard**
+
+If you want to access dashboard via root-ingress controller, you can enable this option:
+
+```bash
+kubectl patch -n tenant-root ingresses.apps.cozystack.io ingress --type=merge -p '{"spec":{
+  "dashboard": true
+}}'
+```
 
 Use `dashboatd.example.org` (under 192.168.100.200) to access system dashboard, where `example.org` is your domain specified for `tenant-root`
 

--- a/content/en/docs/get-started.md
+++ b/content/en/docs/get-started.md
@@ -101,6 +101,17 @@ data:
   ipv4-join-cidr: "100.64.0.0/16"
 EOT
 ```
+{{% alert color="warning" %}}
+If you use PAAS bundles or enable keycloak for distro, add to your configmap:
+```yaml
+data:
+  ...
+  root-host: < YOUR ROOT HOST if known, like: infra.example.org >
+  api-server-adress: < YOUR API SERVER ADRESS, like: 55.21.33.22 or domain name>
+```
+{{% /alert %}}
+
+
 
 Create namespace and install Cozystack system components:
 

--- a/content/en/docs/oidc.md
+++ b/content/en/docs/oidc.md
@@ -81,6 +81,8 @@ kubectl get secret -o yaml -n cozy-keycloak keycloak-credentials -o go-template=
 2. **Add User to the `kubeapps-admin` Group**  
    Assign the user to the `kubeapps-admin` group.
 
-### Step 4: Get Kubeconfig
+### Step 4: Retrieve Kubeconfig
 
-Now access the cluster via Dashboard 
+To access the cluster through the Dashboard, download your kubeconfig by selecting the deployed tenant and copying the secret from the resource map.
+
+This kubeconfig will be automatically configured to use OIDC authentication and the namespace dedicated to the tenant.

--- a/content/en/docs/oidc.md
+++ b/content/en/docs/oidc.md
@@ -1,0 +1,86 @@
+---
+title: "OIDC Server"
+linkTitle: "OIDC Server"
+description: "OIDC Server"
+weight: 35
+---
+
+## Prerequisites
+
+1. **OIDC Configuration**  
+   Your API server must be configured to use OIDC. If you are using Talos Linux, your machine configuration should include the following parameters:
+
+   ```yaml
+   cluster:
+     apiServer:
+       extraArgs:
+         oidc-issuer-url: "https://keycloak.example.org/realms/cozy"
+         oidc-client-id: "kubernetes"
+         oidc-username-claim: "preferred_username"
+         oidc-groups-claim: "groups"
+   ```
+
+2. **Domain Reachability**  
+   Ensure that the domain `keycloak.example.org` is accessible from the cluster and resolves to your root ingress controller.
+
+3. **Storage Configuration**  
+   Storage must be properly configured.
+
+## Configuration
+
+If all prerequisites are met, you can proceed with the configuration steps.
+
+### Step 1: Enable OIDC in Cozystack
+
+Edit your Cozystack ConfigMap to enable OIDC:
+
+```bash
+kubectl patch -n cozy-system configmap cozystack --type=merge -p '{"data":{"oidc-enabled": "true"}}'
+```
+
+Within one minute, CozyStack will reconcile the ConfigMap and create three new `HelmRelease` resources:
+
+```bash
+# kubectl get hr -n cozy-keycloak
+cozy-keycloak                    keycloak                    26s    Unknown   Running 'install' action with a timeout of 5m0s
+cozy-keycloak                    keycloak-configure          26s    False     dependency 'cozy-keycloak/keycloak-operator' is not ready
+cozy-keycloak                    keycloak-operator           26s    False     dependency 'cozy-keycloak/keycloak' is not ready
+```
+
+### Step 2: Wait for Installation Completion  
+
+Wait until all resources are successfully installed and reach the `Ready` state:
+
+```bash
+NAME                 AGE     READY   STATUS
+keycloak             2m19s   True    Helm install succeeded for release cozy-keycloak/keycloak.v1 with chart cozy-keycloak@0.19.0
+keycloak-configure   2m19s   True    Helm install succeeded for release cozy-keycloak/keycloak-configure.v1 with chart cozy-keycloak-configure@0.19.0
+keycloak-operator    2m19s   True    Helm install succeeded for release cozy-keycloak/keycloak-operator.v1 with chart cozy-keycloak-operator@0.19.0
+```
+
+<!-- TODO: automate this -->
+Reconcile tenants:
+
+```
+kubectl annotate -n tenant-root hr/tenant-root reconcile.fluxcd.io/forceAt=$(date +"%Y-%m-%dT%H:%M:%SZ") --overwrite
+```
+
+### Step 3: Access Keycloak  
+
+You can now access Keycloak at `https://keycloak.example.org` (replace `example.org` with your infrastructure domain).
+
+To get the Keycloak credentials, run the following command:
+
+```bash
+kubectl get secret -o yaml -n cozy-keycloak keycloak-credentials -o go-template='{{ printf "%s\n" (index .data "password" | base64decode) }}'
+```
+
+1. **Create a User in the Cozy Realm**  
+   Follow the [Keycloak documentation](https://www.keycloak.org/docs/latest/server_admin/index.html#proc-creating-user_server_administration_guide) to create a user in the Cozy realm.
+
+2. **Add User to the `kubeapps-admin` Group**  
+   Assign the user to the `kubeapps-admin` group.
+
+### Step 4: Get Kubeconfig
+
+Now access the cluster via Dashboard 

--- a/content/en/docs/talos/configuration/talm.md
+++ b/content/en/docs/talos/configuration/talm.md
@@ -30,12 +30,11 @@ Before v0.6.6 Talm:
 ```
   cluster:
     apiServer:
-    apiServer:
       extraArgs:
-      oidc-issuer-url: "https://keycloak.example.com/realms/cozy"
-      oidc-client-id: "kubernetes"
-      oidc-username-claim: "preferred_username"
-      oidc-groups-claim: "groups"
+        oidc-issuer-url: "https://keycloak.example.com/realms/cozy"
+        oidc-client-id: "kubernetes"
+        oidc-username-claim: "preferred_username"
+        oidc-groups-claim: "groups"
 
 {{% /alert %}}
 

--- a/content/en/docs/talos/configuration/talm.md
+++ b/content/en/docs/talos/configuration/talm.md
@@ -19,6 +19,28 @@ cd cluster1
 talm init --preset cozystack
 ```
 
+{{% alert color="warning" %}}
+If you use keycloak.
+
+From v0.6.6 Talm:
+- in `cluster1/templates/_helpers.tpl` replace  `keycloak.example.com` to your domain.
+
+Before v0.6.6 Talm:
+- Add in template args manualy:
+```
+  cluster:
+    apiServer:
+    apiServer:
+      extraArgs:
+      oidc-issuer-url: "https://keycloak.example.com/realms/cozy"
+      oidc-client-id: "kubernetes"
+      oidc-username-claim: "preferred_username"
+      oidc-groups-claim: "groups"
+
+{{% /alert %}}
+
+
+
 The structure of the project mostly mirrors an ordinary Helm chart:
 
 - `charts` - a directory that includes a common library chart with functions used for querying information from Talos Linux.

--- a/content/en/docs/talos/configuration/talm.md
+++ b/content/en/docs/talos/configuration/talm.md
@@ -39,8 +39,6 @@ Before v0.6.6 Talm:
 
 {{% /alert %}}
 
-
-
 The structure of the project mostly mirrors an ordinary Helm chart:
 
 - `charts` - a directory that includes a common library chart with functions used for querying information from Talos Linux.

--- a/content/en/docs/talos/configuration/talos-bootstrap.md
+++ b/content/en/docs/talos/configuration/talos-bootstrap.md
@@ -88,6 +88,23 @@ cluster:
 EOT
 ```
 
+{{% alert color="warning" %}}
+If you use keycloak.
+
+- Add in `patch-controlplane.yaml`:
+  ```
+  cluster:
+    apiServer:
+    apiServer:
+      extraArgs:
+      oidc-issuer-url: "https://keycloak.example.com/realms/cozy"
+      oidc-client-id: "kubernetes"
+      oidc-username-claim: "preferred_username"
+      oidc-groups-claim: "groups"
+
+Where example.com is your root-domain.
+{{% /alert %}}
+
 Run [talos-bootstrap](https://github.com/aenix-io/talos-bootstrap/) to deploy the first node in a cluster:
 
 ```bash
@@ -112,6 +129,3 @@ Talos-bootstrap will enable bootstrap on the first configured node in a cluster.
 Repeat the step for the other nodes in a cluster.
 
 Now follow **Get Started** guide starting from the [**Install Cozystack**](/docs/get-started/#install-cozystack) section, to continue the installation.
-
-
-

--- a/content/en/docs/talos/configuration/talos-bootstrap.md
+++ b/content/en/docs/talos/configuration/talos-bootstrap.md
@@ -102,7 +102,7 @@ If you use keycloak.
       oidc-username-claim: "preferred_username"
       oidc-groups-claim: "groups"
 
-Where example.com is your root-domain.
+Where example.com is your `root-host`.
 {{% /alert %}}
 
 Run [talos-bootstrap](https://github.com/aenix-io/talos-bootstrap/) to deploy the first node in a cluster:

--- a/content/en/docs/users-managment/_index.md
+++ b/content/en/docs/users-managment/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Users Managment"
+linkTitle: "Users Managment"
+description: "Cozystack users managment."
+weight: 20
+---

--- a/content/en/docs/users-managment/users_and_roles.md
+++ b/content/en/docs/users-managment/users_and_roles.md
@@ -1,0 +1,57 @@
+---
+title: Creating users and add roles for them
+linkTitle: Users and roles
+description: "How to create users and add roles for them"
+weight: 30
+---
+
+Creating users and add roles for them
+
+### Overview
+
+When a tenant is created in Cozy (starting with version 1.6.0), roles, RoleBindings and keycloak groups will automatically be created in the Kubernetes cluster.
+
+## Assigning a Role to a User for a Tenant
+
+1. **Access Keycloak**:
+   To retrieve login credentials, check the secret by running the following command:
+   ```bash
+   kubectl get secret keycloak-credentials -n cozy-keycloak -o yaml
+   ```
+   **Keycloak Address**:
+   The Keycloak address will match the value specified in the cozystack ConfigMap. For example, if your ConfigMap looks like this:
+   ```yaml
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+    name: cozystack
+    namespace: cozy-system
+    data:
+    root-host: infra.example.org
+    api-server-adress: 55.21.33.22
+    bundle-name: "paas-full"
+    ipv4-pod-cidr: "10.244.0.0/16"
+    ipv4-pod-gateway: "10.244.0.1"
+    ipv4-svc-cidr: "10.96.0.0/16"
+    ipv4-join-cidr: "100.64.0.0/16"
+   ```
+   Then Keycloak will be available at: `keycloak.infra.example.org`
+
+## Configure Roles for Each Tenant in Cozy:
+
+- **`tenant-abc-view`**
+  - Read-only access to resources from our API.
+  - Ability to view logs.
+
+- **`tenant-abc-use`**
+  - All previous permissions
+  - VNC access for virtual machines.
+
+- **`tenant-abc-admin`**
+  - All previous permissions
+  - Ability to delete pods, along with all permissions from `tenant-abc-use`.
+  - Ability to create, update, and delete resources from our API (excluding `tenant`, `monitoring`, `etcd`, `ingress`).
+
+- **`tenant-abc-super-admin`**
+  - All previous permissions
+  - Ability to create, update, and delete `tenant`, `monitoring`, `etcd`, and `ingress`.

--- a/content/en/docs/users-managment/users_and_roles.md
+++ b/content/en/docs/users-managment/users_and_roles.md
@@ -11,6 +11,9 @@ Creating users and add roles for them
 
 When a tenant is created in Cozy (starting with version 1.6.0), roles, RoleBindings and keycloak groups will automatically be created in the Kubernetes cluster.
 
+To create a user, refer to the following documentation:
+[Keycloak Admin Console Documentation](https://www.keycloak.org/docs/latest/server_admin/#using-the-admin-console)
+
 ## Assigning a Role to a User for a Tenant
 
 1. **Access Keycloak**:

--- a/content/en/docs/virtualization.md
+++ b/content/en/docs/virtualization.md
@@ -47,6 +47,12 @@ This package defines a virtual machine disk used to store data. You can download
    {{< note >}}
    If you want to let virtctl know about right endpoint for uploading images, you need to configure a cluster to specify an endpoint for it:
    1. Modify your `ingress` application to enable `cni-uploadproxy` option.
+      ```bash
+      kubectl patch -n tenant-root ingresses.apps.cozystack.io ingress --type=merge -p '{"spec":{
+        "cdiUploadProxy": true
+      }}'
+
+   <!-- TODO: automate this -->
    2. Modify your cozystack config to provide a valid CDI uploadproxy endpoint:
    ```yaml
    values-cdi: |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added installation and execution instructions for Hugo in the README.
	- Introduced a new "Users Management" section in the documentation.
	- Created a guide on user creation and role assignment within the Cozy platform.
	- Added a comprehensive guide for configuring an OIDC server within a Kubernetes environment using Talos Linux.

- **Documentation**
	- Enhanced clarity on configuration parameters and server requirements in the Cozystack setup documentation.
	- Improved instructions for accessing Keycloak and managing user roles.
	- Updated Talm documentation with specific Keycloak integration instructions based on version.
	- Added detailed instructions for integrating Keycloak with the Talos Linux cluster setup.
	- Included a new command snippet for configuring the `cdiUploadProxy` option in the virtualization documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->