### PR TITLE
Add KubeSpan to the documentation

### DIFF
--- a/content/en/docs/faq.md
+++ b/content/en/docs/faq.md
@@ -61,6 +61,40 @@ data:
 :warning: Disabling components using this option will not remove them if they are already installed. To remove them, you must delete the Helm release manually using the `kubectl delete hr -n <namespace> <component>` command.
 {{% /alert %}}
 
+### Configuration
+
+#### How to Enable KubeSpan
+
+Talos Linux provides a full mesh WireGuard network for your cluster.
+
+To enable this functionality, you need to configure [KubeSpan](https://www.talos.dev/v1.8/talos-guides/network/kubespan/) and [Cluster Discovery](https://www.talos.dev/v1.2/kubernetes-guides/configuration/discovery/) in your Talos Linux configuration:
+
+```yaml
+machine:
+  network:
+    kubespan:
+      enabled: true
+cluster:
+  discovery:
+    enabled: false
+```
+
+Since KubeSpan encapsulates traffic into a WireGuard tunnel, Kube-OVN should also be configured with a lower MTU value.
+
+To achieve this, add the following to the Cozystack ConfigMap:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cozystack
+  namespace: cozy-system
+data:
+  values-kubeovn: |
+    kube-ovn:
+      mtu: 1222
+```
+
 ### Operations
 
 #### How to enable access to dashboard via ingress-controller


### PR DESCRIPTION
depends on https://github.com/aenix-io/cozystack/pull/487

Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a "Configuration" section in the FAQ, detailing how to enable KubeSpan in Talos Linux.
	- Added instructions for configuring KubeSpan and adjusting the MTU value for Kube-OVN, including a YAML snippet for the CozyStack ConfigMap. 
- **Documentation**
	- Enhanced troubleshooting information for users implementing KubeSpan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->