### PR TITLE
Add info about cluster wide roles

### DIFF
--- a/content/en/docs/oidc.md
+++ b/content/en/docs/oidc.md
@@ -77,6 +77,9 @@ kubectl get secret -o yaml -n cozy-keycloak keycloak-credentials -o go-template=
 
 1. **Create a User in the Cozy Realm**  
    Follow the [Keycloak documentation](https://www.keycloak.org/docs/latest/server_admin/index.html#proc-creating-user_server_administration_guide) to create a user in the Cozy realm.
+   {{% alert color="info" %}}
+   User must be with verified email.
+   {{% /alert %}}
 
 2. **Add User to the `kubeapps-admin` Group**  
    Assign the user to the `kubeapps-admin` group.

--- a/content/en/docs/oidc.md
+++ b/content/en/docs/oidc.md
@@ -78,7 +78,11 @@ kubectl get secret -o yaml -n cozy-keycloak keycloak-credentials -o go-template=
 1. **Create a User in the Cozy Realm**  
    Follow the [Keycloak documentation](https://www.keycloak.org/docs/latest/server_admin/index.html#proc-creating-user_server_administration_guide) to create a user in the Cozy realm.
    {{% alert color="info" %}}
-   User must be with verified email.
+   Users must have a verified email address in Keycloak. This is required for proper OIDC authentication.
+   To verify an email:
+   1. Access the user details in Keycloak admin console
+   2. Navigate to the Credentials tab
+   3. Use the "Email Verification" action
    {{% /alert %}}
 
 2. **Add User to the `kubeapps-admin` Group**  

--- a/content/en/docs/users-managment/users_and_roles.md
+++ b/content/en/docs/users-managment/users_and_roles.md
@@ -42,6 +42,15 @@ To create a user, refer to the following documentation:
 
 ## Configure Roles for Each Tenant in Cozy:
 
+### Cluster wide
+- **`cozystack-cluster-admin`**
+  - Allow all.
+
+- **`kubeapps-admin`**
+  - Allow all in "" api group
+  - Allow all for helmreleases in helm.toolkit.fluxcd.io and apps.cozystack.io
+
+### Tenant wide
 - **`tenant-abc-view`**
   - Read-only access to resources from our API.
   - Ability to view logs.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated OIDC documentation to include user email verification steps in Keycloak.
	- Added a new section on role configurations for users in a Kubernetes environment, detailing "Cluster wide" and "Tenant wide" roles with specific permissions.

- **Documentation**
	- Enhanced guidance on user management within the Cozy platform through new role definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->