### PR TITLE
feature/add-multi-dc

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Cozystack.io website
 ```bash
 wget https://github.com/gohugoio/hugo/releases/download/v0.122.0/hugo_extended_0.122.0_linux-amd64.tar.gz
 tar -xzf hugo_extended_0.122.0_linux-amd64.tar.gz
- chmod +x /usr/local/bin/hugo
+sudo mv hugo /usr/local/bin/
+chmod +x /usr/local/bin/hugo
 ```
 
 ## Run docs


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated installation instructions for Hugo to ensure a smoother setup process.
  - Added a new "Multi DC configuration" section in the FAQ, detailing how to label nodes and configure PodTopologySpread for Kubernetes.
  - Made minor formatting improvements to existing sections for enhanced readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->