### PR TITLE
Add notes about running on nodes in multiple datacenters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 # cozystack-website
+
 Cozystack.io website
 
 ## Install hugo
+
+Be sure to download the extended version of Hugo from the GitHub releases page. The binary that was installed by your
+operating system package manager may (and most likely will) not work correctly.
+
 ```bash
 wget https://github.com/gohugoio/hugo/releases/download/v0.122.0/hugo_extended_0.122.0_linux-amd64.tar.gz
 tar -xzf hugo_extended_0.122.0_linux-amd64.tar.gz
@@ -9,6 +14,7 @@ tar -xzf hugo_extended_0.122.0_linux-amd64.tar.gz
 ```
 
 ## Run docs
+
 ```bash
 hugo serve
 ```

--- a/content/en/docs/stretched/_index.md
+++ b/content/en/docs/stretched/_index.md
@@ -1,0 +1,8 @@
+---
+title: "Multi Datacenter guides"
+linkTitle: "Multi Datacenter"
+description: "How to run Cozystack on stretched Kubernetes cluster"
+weight: 37
+---
+
+These guides will show you how to configure your cluster to run Cozystack on the nodes residing in different datacenters.

--- a/content/en/docs/stretched/etcd.md
+++ b/content/en/docs/stretched/etcd.md
@@ -7,10 +7,10 @@ weight: 10
 
 ## Potential problems
 
-**etcd** is a reliable key-value store for critical data, the place where the Kubernetes API server stores its data. Values
-are not considered written until a quorum of nodes report that data has been written. Also, etcd constantly checks that
-there is a leader and every node is aware which one it is. Usually, an etcd cluster is run on nodes in the same
-datacenter (where latency is low) and default timeouts are tuned for the quickest error reporting possible. In a
+**etcd** is a reliable key-value store for critical data, the place where the Kubernetes API server stores its data.
+Values are not considered written until a quorum of nodes reports that data has been written. Also, etcd constantly
+checks that there is a leader and every node is aware which one it is. Usually, an etcd cluster is run on nodes in the
+same datacenter (where latency is low) and default timeouts are tuned for the quickest error reporting possible. In a
 stretched cluster, where nodes are in different datacenters, the RTT is much higher and default timeouts can cause false
 alarms as if the network was partitioned. In this case, the data is still consistent, but etcd will enter readonly mode
 to prevent split-brain. This could happen so frequently that many other components of Kubernetes would start to fail

--- a/content/en/docs/stretched/etcd.md
+++ b/content/en/docs/stretched/etcd.md
@@ -34,6 +34,7 @@ An example of command-line arguments for etcd:
 When using `talm` to manage your Talos nodes, add parameters to the `cluster.etcd` section of the template:
 
 ```yaml
+cluster:
   etcd:
     extraArgs:
       heartbeat-interval: "1000"

--- a/content/en/docs/stretched/etcd.md
+++ b/content/en/docs/stretched/etcd.md
@@ -1,0 +1,41 @@
+---
+title: "Tune etcd timeouts"
+linkTitle: "etcd configuration"
+description: "Parameters required to make etcd work in a stretched cluster"
+weight: 10
+---
+
+## Potential problems
+
+**etcd** is a reliable key-value store for critical data, the place where the Kubernetes API server stores its data. Values
+are not considered written until a quorum of nodes report that data has been written. Also, etcd constantly checks that
+there is a leader and every node is aware which one it is. Usually, an etcd cluster is run on nodes in the same
+datacenter (where latency is low) and default timeouts are tuned for the quickest error reporting possible. In a
+stretched cluster, where nodes are in different datacenters, the RTT is much higher and default timeouts can cause false
+alarms as if the network was partitioned. In this case, the data is still consistent, but etcd will enter readonly mode
+to prevent split-brain. This could happen so frequently that many other components of Kubernetes would start to fail
+with non-descriptive and unhelpful error messages.
+
+## Configuration
+
+To prevent frequent leader re-elections, you need to tune the following parameters in the etcd configuration:
+
+* `heartbeat-interval` - the time between heartbeats
+* `election-timeout` - the time to wait for a heartbeat before starting an election
+
+An example of command-line arguments for etcd:
+
+```
+--election-timeout=10000 --heartbeat-interval=1000
+```
+
+## Talos example
+
+When using `talm` to manage your Talos nodes, add parameters to the `cluster.etcd` section of the template:
+
+```yaml
+  etcd:
+    extraArgs:
+      heartbeat-interval: "1000"
+      election-timeout: "10000"
+```

--- a/content/en/docs/stretched/labels.md
+++ b/content/en/docs/stretched/labels.md
@@ -1,0 +1,47 @@
+---
+title: "Node labels"
+linkTitle: "Topology node labels"
+description: "Label your nodes to help the workloads to be scheduled correctly"
+weight: 20
+---
+
+## How topology labels work
+
+When running a Kubernetes cluster in multiple datacenters, it's important to know when you want to schedule workloads
+close to each other (for example, a database and a backend application) or when you want to spread them out (for
+example, multiple replicas of frontend, or database replicas, or volume replicas). The first step to achieving this is
+to label Kubernetes nodes. Public clouds typically use the `zone` and `region` terms. In Kubernetes, the most common way
+to designate a geographical location is to use `topology.kubernetes.io/zone` and `topology.kubernetes.io/region`
+labels (or only the zone one).
+
+## Talos example
+
+While labels are usually set manually in other Kubernetes distributions, with Talos you can describe the topology as
+code.
+
+Example `talm` configuration:
+
+`values.yaml`:
+
+```yaml
+nodes:
+  node1:
+    labels:
+      topology.kubernetes.io/zone: "us-west-1"
+      topology.kubernetes.io/region: "us-west"
+  node2:
+    labels:
+      topology.kubernetes.io/zone: "us-east-1"
+      topology.kubernetes.io/region: "us-east"
+```
+
+`_helpers.tpl`:
+
+```helm
+{{- $nodeLabels := .Values.nodes | dig (include "talm.discovered.hostname" .) "labels" nil }}
+machine:
+  {{- with $nodeLabels }}
+  nodeLabels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+```

--- a/content/en/docs/stretched/linstor.md
+++ b/content/en/docs/stretched/linstor.md
@@ -1,0 +1,30 @@
+---
+title: "Linstor DRBD parameters"
+linkTitle: "Linstor configuration"
+description: "Parameters required to make Linstor work in a stretched cluster"
+weight: 20
+---
+
+## Potential problems
+
+Linstor server manages DRBD volumes and is responsible for creating, deleting, and managing them. DRBD itself is a
+kernel-level block device replication system that works over the network. It requires that data has been written to a
+quorum of nodes before it is considered written. But it also poses as a block device to the end user, so it must return
+an error in a timely manner if there are not enough nodes to establish a quorum.
+
+The potential problem is the same as with etcd - the default timeouts are tuned for local-area networks with high
+bandwidth and low latency. In the case of cross-datacenter communication, the ack from the remote node can take a long
+time due to network congestion.
+
+If a single DRBD device is reported as having lost quorum, the Piraeus HA controller will fence the node to prevent
+other workloads from failing. This can lead to non-schedulable workloads and even a rebalance storm.
+
+## Configuration
+
+While it's possible to tune the timeouts for every DRBD resource, it's much easier to set global parameters for the
+Linstor cluster once:
+
+```
+# this will also adjust the timeouts for existing DRBD resources immediately
+linstor controller drbd-options --connect-int 15 --ping-int 15 --ping-timeout 20 --drbd-timeout 120
+```

--- a/content/en/docs/stretched/linstor.md
+++ b/content/en/docs/stretched/linstor.md
@@ -2,7 +2,7 @@
 title: "Linstor DRBD parameters"
 linkTitle: "Linstor configuration"
 description: "Parameters required to make Linstor work in a stretched cluster"
-weight: 20
+weight: 30
 ---
 
 ## Potential problems


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Enhanced installation instructions by specifying that users should download the extended version of Hugo for proper functionality.
  - Added new guides offering multi-datacenter deployment insights, including recommendations for configuring Kubernetes clusters.
  - Introduced detailed documentation covering optimal timeout settings for etcd in stretched clusters, including configuration examples.
  - Provided guidance on Linstor DRBD parameters for managing quorum requirements and timeout adjustments in stretched environments.
  - Added documentation on effectively using topology labels in Kubernetes clusters, including examples for configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->